### PR TITLE
Fixed demo and linting errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ export default class BookshelfDemo {
 
     ReactDOM.render(
       <IntlProvider locale={this.intlObj.getLocale()} messages={this.intlObj.getMessages()}>
-        <ComponentOwner books={config.books} onBookClick={config.onBookClick} />
+        <ComponentOwner books={config.books} onBookClick={config.onBookClick} locale={config.locale} />
       </IntlProvider>,
       document.getElementById(config.elementId)
     );

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "url": "https://github.com/Pearson-Higher-Ed/"
   },
   "dependencies": {
-    "react-intl": "~2.0.1",
-    "@pearson-incubator/aquila-js-core": "^0.2.32"
+    "@pearson-incubator/aquila-js-core": "^0.2.32",
+    "prop-types": "^15.5.10",
+    "react-intl": "^2.3.0"
   },
   "devDependencies": {
     "@pearson-components/npm-scripts": "^0.1.0",
@@ -42,6 +43,7 @@
     "colors": "~1.1.2",
     "conventional-changelog": "~1.1.0",
     "css-loader": "~0.23.0",
+    "element-resize-event": "^2.0.5",
     "eslint": "~1.10.3",
     "eslint-loader": "~1.1.1",
     "eslint-plugin-react": "~3.16.1",
@@ -52,9 +54,9 @@
     "jsdom": "~8.5.0",
     "json-loader": "~0.5.4",
     "lodash": "^4.17.2",
-    "material-ui": "^0.16.3",
+    "material-ui": "^0.16.7",
     "mocha": "~2.4.5",
-    "node-sass": "~3.4.2",
+    "node-sass": "^4.5.2",
     "pearson-elements": "^0.10.0",
     "pseudoloc": "^1.1.0",
     "react": "^15.4.0",
@@ -62,19 +64,19 @@
     "react-dimensions": "^1.3.0",
     "react-dom": "^15.4.0",
     "react-tap-event-plugin": "~2.0.1",
-    "sass-loader": "~3.2.0",
+    "sass-loader": "^4.1.1",
     "semver": "~5.1.0",
     "style-loader": "~0.13.0",
     "url-loader": "~0.5.7",
-    "webpack": "~1.12.9",
+    "webpack": "^1.15.0",
     "webpack-dev-server": "~1.14.0"
   },
   "peerDependencies": {
-    "material-ui": "^0.16.3",
+    "material-ui": "^0.16.7",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-tap-event-plugin": "~2.0.1",
-    "react-intl": "~2.1.5"
+    "react-intl": "^2.3.0"
   },
   "keywords": [
     "pearson-components"

--- a/src/js/Book.jsx
+++ b/src/js/Book.jsx
@@ -17,10 +17,10 @@ export default class Book extends Component {
 
   handleBookClick() {
     if (this.props.onBookClick) {
-      if(this.props.book.iseT1){
-        this.props.onBookClick(this.props.id,this.props.book.iseT1);   
+      if (this.props.book.iseT1) {
+        this.props.onBookClick(this.props.id, this.props.book.iseT1);
         this.props.storeBookDetails(this.props.book);    
-      }else{    
+      } else {
         this.props.onBookClick(this.props.id);    
       }
     }
@@ -59,7 +59,7 @@ export default class Book extends Component {
           padding:'5.9% 6.4%'
         }
       }
-    }
+    };
     
     return (
       <div className={`book ${bookCoverExists ? '' : 'no-book-cover'}`}>

--- a/src/js/Bookshelf.jsx
+++ b/src/js/Bookshelf.jsx
@@ -16,8 +16,7 @@ class Bookshelf extends Component {
     const componentWidth = this.props.containerWidth;
     const bookWidth = 220;
     const booksPerRow = floor(componentWidth / bookWidth);
-    const checkRows = this.props.books.length >= booksPerRow ? true : false;
-    const margin = ((componentWidth - (bookWidth * booksPerRow) - 13) / booksPerRow) / 2;
+    const checkRows = this.props.books.length >= booksPerRow;
     this.setState({
       //reqMargin: margin,
       checkRows: checkRows
@@ -55,9 +54,9 @@ class Bookshelf extends Component {
 
   render() {
     let txtAlign;
-    if(this.state.checkRows) {
+    if (this.state.checkRows) {
       txtAlign ='left';
-    }else {
+    } else {
       txtAlign ='center';
     }
     return (
@@ -65,7 +64,7 @@ class Bookshelf extends Component {
           <div className="bookshelf-body" style={{textAlign:txtAlign}}>
             {(this.props.books.length === 0) ? this.renderEmpty() : this.renderBooks()}
           </div>
-          <div id="books-assert-container" role="alert" aria-live="assertive" className="reader-only"></div>
+          <div id="books-assert-container" role="alert" aria-live="assertive" className="reader-only"/>
       </div>          
     )    
   }
@@ -75,4 +74,4 @@ Bookshelf.propTypes = {
   intl: intlShape.isRequired
 };
 
-export default Dimensions()(injectIntl(Bookshelf));
+export default new Dimensions()(injectIntl(Bookshelf));

--- a/src/js/component-owner.js
+++ b/src/js/component-owner.js
@@ -1,11 +1,12 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { darkBlack, fullBlack } from 'material-ui/styles/colors';
 
-import BookshelfComponent from './BookshelfComponent';
+import { BookshelfComponent } from './BookshelfComponent';
 
 const muiTheme = getMuiTheme({
   palette: {    
@@ -25,7 +26,7 @@ class ComponentOwner extends React.Component {
     };
   }
 
-  render() {    
+  render() {
     return (
       <MuiThemeProvider muiTheme={muiTheme}>
         <BookshelfComponent


### PR DESCRIPTION
* Added dev dependency element-resize-event to enforce version 2.0.5 as React-dimensions uses element-resize-event which introduces bug after 2.0.5.
* Updated react-intl as React deprecated use of React.PropTypes
* Added Prototypes as React deprecated use of React.PropTypes
* Updated node-sass, sass-loader(4.1.1, >4.1.1 requires webpack 2) due to fatal error
* Updated webpack to 1.15